### PR TITLE
Correct sign in `CustomLinearEquationOfState` plus single R_rho calculation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StaircaseShenanigans"
 uuid = "c2bb06a8-94f3-4279-b990-30bf3ab8ba6f"
 authors = ["Josef Bisits <jbisits@gmail.com>"]
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 GibbsSeaWater = "9a22fb26-0b63-4589-b28e-8f9d0b5c3d05"

--- a/examples/four_stair_staircase.jl
+++ b/examples/four_stair_staircase.jl
@@ -12,7 +12,8 @@ salinity = [34.55, 34.60, 34.65, 34.70, 34.75]
 temperature = [-1.5, -1.0, -0.5, 0.0, 0.5]
 
 ## Setup the model
-model = DNSModel(architecture, domain_extent, resolution, diffusivities)
+eos = CustomLinearEquationOfState(0, 34.6)
+model = DNSModel(architecture, domain_extent, resolution, diffusivities, eos)
 
 ## Set initial conditions
 step_ics = StepInitialConditions(model, number_of_steps, depth_of_steps, salinity, temperature)

--- a/examples/four_stair_staircase.jl
+++ b/examples/four_stair_staircase.jl
@@ -8,16 +8,11 @@ resolution = (Nx = 5, Ny = 5, Nz = 50)
 ## Initial conditions
 number_of_steps = 4
 depth_of_steps = [-0.2, -0.4, -0.6, -0.8]
-salinity = [34.57, 34.60, 34.63, 34.66, 34.69]
+salinity = [34.55, 34.60, 34.65, 34.70, 34.75]
 temperature = [-1.5, -1.0, -0.5, 0.0, 0.5]
 
 ## Setup the model
-rate = 1/40
-mask = OuterStairMask(depth_of_steps)
-target = OuterStairTargets(depth_of_steps, salinity)
-S_relaxation = Relaxation(; rate, mask, target)
-relaxation = (S = S_relaxation,)
-model = DNSModel(architecture, domain_extent, resolution, diffusivities; relaxation)
+model = DNSModel(architecture, domain_extent, resolution, diffusivities)
 
 ## Set initial conditions
 step_ics = StepInitialConditions(model, number_of_steps, depth_of_steps, salinity, temperature)

--- a/src/alt_lineareos.jl
+++ b/src/alt_lineareos.jl
@@ -5,7 +5,7 @@ using GibbsSeaWater.jl from `Θ` and `S` (`S` is practical salinity).
 """
 function CustomLinearRoquetSeawaterPolynomial(Θ, S, reference_density, FT)
 
-    α = reference_density * gsw_alpha(S, Θ, 0)
+    α = -reference_density * gsw_alpha(S, Θ, 0)
     β = reference_density * gsw_beta(S, Θ, 0)
 
     return SecondOrderSeawaterPolynomial{FT}(R₀₁₀ = α,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,8 +20,11 @@ using Test
         ΔS, ΔΘ = diff(salinity[1:2]), diff(temperature[1:2])
         Sₘ, Θₘ = (sum(salinity[1:2]) / 2), (sum(temperature[1:2]) / 2)
         β = haline_contraction(Θₘ, Sₘ, 0, model.buoyancy.model.equation_of_state)
-        α = thermal_expansion(Θₘ, Sₘ, 0, model.buoyancy.model.equation_of_state)
+        α = -thermal_expansion(Θₘ, Sₘ, 0, model.buoyancy.model.equation_of_state)
 
+        println(α, β)
+        println(sdns.initial_conditions.R_ρ)
+        println((β * ΔS) / (α * ΔΘ))
         @test all(sdns.initial_conditions.R_ρ .≈ (β * ΔS) / (α * ΔΘ))
 
     end
@@ -32,7 +35,7 @@ using Test
             Θ = rand(range(-1.5, 20.5, length = 20))
             S = rand(range(34.5, 34.7, length = 20))
             ρ₀ = 1024.6
-            true_coefficients = ρ₀ * gsw_alpha(S, Θ, 0), ρ₀ * gsw_beta(S, Θ, 0)
+            true_coefficients = -ρ₀ * gsw_alpha(S, Θ, 0), ρ₀ * gsw_beta(S, Θ, 0)
             custom_linear = CustomLinearEquationOfState(Θ, S, reference_density = ρ₀)
             sp = custom_linear.seawater_polynomial
             linear_coefficients = sp.R₀₁₀, sp.R₁₀₀


### PR DESCRIPTION
I think to set $\alpha$ correctly in `CustomLinearEquationOfState` it needs to be negative. This came about when computing the density ratio using the same method as non-linear equation of state where the values for the density ratio did not have the same sign as the non-linear equation of state case. This also explains why I was not getting anything triggered in the linear case because (I think) the $R_{\rho}$ had the wrong sign so was very stable.

I need to run an experiment to check but I think this is correct. If it is correct I think I will bump to v0.3.0