### PR TITLE
Add tracer content restoring within a layer of a staircase simulation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StaircaseShenanigans"
 uuid = "c2bb06a8-94f3-4279-b990-30bf3ab8ba6f"
 authors = ["Josef Bisits <jbisits@gmail.com>"]
-version = "0.3"
+version = "0.3.0"
 
 [deps]
 GibbsSeaWater = "9a22fb26-0b63-4589-b28e-8f9d0b5c3d05"
@@ -11,6 +11,7 @@ Oceananigans = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 SeawaterPolynomials = "d496a93d-167e-4197-9f49-d3af4ff8fe40"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [weakdeps]
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StaircaseShenanigans"
 uuid = "c2bb06a8-94f3-4279-b990-30bf3ab8ba6f"
 authors = ["Josef Bisits <jbisits@gmail.com>"]
-version = "0.3.0"
+version = "0.3.1"
 
 [deps]
 GibbsSeaWater = "9a22fb26-0b63-4589-b28e-8f9d0b5c3d05"

--- a/examples/single_interface.jl
+++ b/examples/single_interface.jl
@@ -6,8 +6,8 @@ domain_extent = (Lx = 0.1, Ly = 0.1, Lz = -1.0)
 resolution = (Nx = 5, Ny = 5, Nz = 50)
 
 ## Initial conditions
-number_of_steps = 1
-depth_of_steps = [-0.5]
+number_of_interfaces = 1
+depth_of_interfaces = [-0.5]
 salinity = [34.58, 34.70]
 temperature = [-1.5, 0.5]
 
@@ -27,7 +27,7 @@ forcing = (S = S_restoring, T = T_restoring)
 model = DNSModel(architecture, domain_extent, resolution, diffusivities, eos)
 
 ## Set initial conditions
-step_ics = StepInitialConditions(model, number_of_steps, depth_of_steps, salinity, temperature)
+step_ics = StepInitialConditions(model, number_of_interfaces, depth_of_interfaces, salinity, temperature)
 
 sdns = StaircaseDNS(model, step_ics)
 

--- a/examples/single_interface.jl
+++ b/examples/single_interface.jl
@@ -13,6 +13,8 @@ temperature = [-1.5, 0.5]
 
 ## Setup the model
 eos = CustomLinearEquationOfState(0, 34.6)
+
+## restoring
 rate = 1/10
 mask = OuterMask(-0.25, -0.75)
 S_target = OuterTargets(34.58, 34.7, mask)
@@ -20,7 +22,9 @@ T_target = OuterTargets(-1.5, 0.5, mask)
 T_restoring = Relaxation(; rate, mask, target = T_target)
 S_restoring = Relaxation(; rate, mask, target = S_target)
 forcing = (S = S_restoring, T = T_restoring)
-model = DNSModel(architecture, domain_extent, resolution, diffusivities; forcing)
+
+## model
+model = DNSModel(architecture, domain_extent, resolution, diffusivities, eos)
 
 ## Set initial conditions
 step_ics = StepInitialConditions(model, number_of_steps, depth_of_steps, salinity, temperature)
@@ -31,11 +35,17 @@ set_staircase_initial_conditions!(sdns)
 
 ## Build simulation
 Δt = 1e-1
-stop_time = 2 * 60 # seconds
+stop_time = 50 * 60 # seconds
 save_schedule = 10  # seconds
 output_path = joinpath(@__DIR__, "output")
 simulation = SDNS_simulation_setup(sdns, Δt, stop_time, save_schedule, save_computed_output!;
                                    output_path, max_Δt = 5)
+
+## Callback function for mean temperature field
+
+simulation.callbacks[:T_mean] = Callback(restore_field_region!, IterationInterval(1),
+                                         parameters = (C = :T, compute_mean_region = 0.25,
+                                                      tracer_flux_placement = 0.1))
 
 ## Run
 run!(simulation)

--- a/examples/single_interface.jl
+++ b/examples/single_interface.jl
@@ -40,7 +40,9 @@ save_schedule = 10  # seconds
 output_path = joinpath(@__DIR__, "output")
 simulation = SDNS_simulation_setup(sdns, Δt, stop_time, save_schedule, save_computed_output!,
                                     StaircaseShenanigans.no_velocities!,
-                                    S_and_T_tracer_callbacks!; output_path, max_Δt = 5)
+                                    S_and_T_tracer_callbacks!; output_path, max_Δt = 5,
+                                    # flux_placement = 0.05
+                                    )
 
 ## Run
 run!(simulation)

--- a/examples/single_interface.jl
+++ b/examples/single_interface.jl
@@ -40,8 +40,7 @@ save_schedule = 10  # seconds
 output_path = joinpath(@__DIR__, "output")
 simulation = SDNS_simulation_setup(sdns, Δt, stop_time, save_schedule, save_computed_output!,
                                     StaircaseShenanigans.no_velocities!,
-                                    S_and_T_tracer_callbacks!; output_path, max_Δt = 5,
-                                    # flux_placement = 0.05
+                                    S_and_T_tracer_restoring_callbacks!; output_path, max_Δt = 5,
                                     )
 
 ## Run

--- a/examples/single_interface.jl
+++ b/examples/single_interface.jl
@@ -38,14 +38,9 @@ set_staircase_initial_conditions!(sdns)
 stop_time = 50 * 60 # seconds
 save_schedule = 10  # seconds
 output_path = joinpath(@__DIR__, "output")
-simulation = SDNS_simulation_setup(sdns, Δt, stop_time, save_schedule, save_computed_output!;
-                                   output_path, max_Δt = 5)
-
-## Callback function for mean temperature field
-
-simulation.callbacks[:T_mean] = Callback(restore_field_region!, IterationInterval(1),
-                                         parameters = (C = :T, compute_mean_region = 0.25,
-                                                      tracer_flux_placement = 0.1))
+simulation = SDNS_simulation_setup(sdns, Δt, stop_time, save_schedule, save_computed_output!,
+                                    StaircaseShenanigans.no_velocities!,
+                                    S_and_T_tracer_callbacks!; output_path, max_Δt = 5)
 
 ## Run
 run!(simulation)

--- a/src/StaircaseShenanigans.jl
+++ b/src/StaircaseShenanigans.jl
@@ -8,6 +8,7 @@ using SeawaterPolynomials: BoussinesqEquationOfState
 using SeawaterPolynomials: thermal_expansion, haline_contraction, ρ
 using GibbsSeaWater: gsw_alpha, gsw_beta
 using NCDatasets, JLD2
+using Statistics
 
 import SeawaterPolynomials.SecondOrderSeawaterPolynomials: RoquetSeawaterPolynomial
 
@@ -26,7 +27,7 @@ export AbstractNoise, VelocityNoise
 
 export OuterStairMask, OuterStairTargets, OuterMask, OuterTargets, ExponentialTarget
 
-export restore_field_region!
+export restore_field_region!, S_and_T_tracer_callbacks!
 
 export CustomLinearRoquetSeawaterPolynomial, CustomLinearEquationOfState
 

--- a/src/StaircaseShenanigans.jl
+++ b/src/StaircaseShenanigans.jl
@@ -27,7 +27,7 @@ export AbstractNoise, VelocityNoise
 
 export OuterStairMask, OuterStairTargets, OuterMask, OuterTargets, ExponentialTarget
 
-export restore_field_region!, S_and_T_tracer_callbacks!
+export restore_field_region!, S_and_T_tracer_restoring_callbacks!
 
 export CustomLinearRoquetSeawaterPolynomial, CustomLinearEquationOfState
 

--- a/src/StaircaseShenanigans.jl
+++ b/src/StaircaseShenanigans.jl
@@ -26,6 +26,8 @@ export AbstractNoise, VelocityNoise
 
 export OuterStairMask, OuterStairTargets, OuterMask, OuterTargets, ExponentialTarget
 
+export restore_field_region!
+
 export CustomLinearRoquetSeawaterPolynomial, CustomLinearEquationOfState
 
 export save_computed_output!

--- a/src/staircase_model.jl
+++ b/src/staircase_model.jl
@@ -357,14 +357,15 @@ function checkpointer_setup!(simulation, model, output_dir,
 end
 checkpointer_setup!(simulation, model, output_dir, checkpointer_time_interval::Nothing) = nothing
 """
-    function S_and_T_tracer_callbacks!(simulation, flux_placement; iteration_frequency = 1)
+    S_and_T_tracer_restoring_callbacks!(simulation, flux_placement; iteration_frequency = 1)
 Add `Callback`s to the `S` and `T` fields which act as restoring using [restore_tracer_content!](@ref)
 """
-function S_and_T_tracer_callbacks!(simulation, flux_placement; iteration_frequency = 1)
+function S_and_T_tracer_restoring_callbacks!(simulation, flux_placement; iteration_frequency = 1)
 
     Δx, Δy, Δz = xspacings(simulation.model.grid, Center()), yspacings(simulation.model.grid, Center()),
                     zspacings(simulation.model.grid, Center())
     ΔV = Δx * Δy * Δz
+
     initial_upper_T_content = sum(interior(simulation.model.tracers.T, :, :, 26:50)) * ΔV
     initial_lower_T_content = sum(interior(simulation.model.tracers.T, :, :, 1:25)) * ΔV
 
@@ -376,6 +377,7 @@ function S_and_T_tracer_callbacks!(simulation, flux_placement; iteration_frequen
 
     initial_upper_S_content = sum(interior(simulation.model.tracers.S, :, :, 26:50)) * ΔV
     initial_lower_S_content = sum(interior(simulation.model.tracers.S, :, :, 1:25)) * ΔV
+
     simulation.callbacks[:S_restore] = Callback(restore_tracer_content!, IterationInterval(iteration_frequency),
                                                 parameters = (C = :S,
                                                               tracer_flux_placement = flux_placement,

--- a/src/staircase_restoring.jl
+++ b/src/staircase_restoring.jl
@@ -105,6 +105,9 @@ which is the region of the domain over which to compute the mean and the `tracer
 which is the part of the domain where the tracer flux is added. The arguments are just `Numbers`
 and the regions are computed symetrically as `lower_region` and `upper_region` from the lower
 extent of the domain, `-Lz` and the surface at 0.
+
+There is a default setup in [SDNS_simulation_setup](@ref) allows passing the kwargs
+`mean_region` and `flux_placement` to specify these these parameter
 """
 function restore_field_region!(sim, parameters)
 

--- a/src/staircase_restoring.jl
+++ b/src/staircase_restoring.jl
@@ -99,10 +99,9 @@ single interface.
 ## Parameters
 
 The parameters container needs to know the tracer `C` as a `Symbol`, the `computed_mean_region`
-which is the region of the domain over which to compute the mean and the `tracer_flux_region`
-which is the part of the domain where the tracer flux is added. The arguments are just `Numbers`
-and the regions are computed symetrically as `lower_region` and `upper_region` from the lower
-extent of the domain, `-Lz` and the surface at 0.
+and the `tracer_flux_placement` which is where the flux to maintain approximately equal tracer
+content is placed. Using `tracer_flux_placement` creates a `lower_region` and `upper_region`
+from the lower extent of the domain, `-Lz`, and the surface at `0` respectively.
 
 There is a default setup in [SDNS_simulation_setup](@ref) allows passing the kwargs
 `mean_region` and `flux_placement` to specify these these parameter
@@ -117,16 +116,11 @@ function restore_tracer_content!(sim, parameters)
     z = znodes(sim.model.grid, Center())
 
     tracer = getproperty(sim.model.tracers, parameters.C)
-    cmr = parameters.compute_mean_region
     tfp = parameters.tracer_flux_placement
     iuc = parameters.initial_upper_content
     ilc = parameters.initial_lower_content
 
-    # lower_region = findall(z .≤ (1 - cmr) * Lz)
-    # est_lower_region_tracer_content = 2 * sum(interior(tracer, :, :, lower_region)) * ΔV
     lower_tracer_content_lost = ilc - sum(interior(tracer, :, :, 26:50)) * ΔV
-    # upper_region = findall(z .≥ cmr * Lz)
-    # est_upper_region_tracer_content = 2 * sum(interior(tracer, :, :, upper_region)) * ΔV
     upper_tracer_content_lost = iuc - sum(interior(tracer, :, :, 1:25)) * ΔV
 
     lower_placement = findall(z .< (1 - tfp) * Lz)

--- a/src/staircase_restoring.jl
+++ b/src/staircase_restoring.jl
@@ -69,7 +69,7 @@ struct OuterTargets{T}
     "Upper region depth"
     upper_depth :: T
 end
-Base.summary(oqt::OuterMask) = "Upper target = $(oqt.upper), lower target = $(oqt.lower)"
+Base.summary(oqt::OuterTargets) = "Upper target = $(oqt.upper_target), lower target = $(oqt.lower_target)"
 
 "Convenience constructor to get the upper region of domain from an `OuterMask`"
 OuterTargets(upper_target, lower_target, mask::OuterMask) =
@@ -109,13 +109,13 @@ extent of the domain, `-Lz` and the surface at 0.
 function restore_field_region!(sim, parameters)
 
     Lx, Ly, Lz = sim.model.grid.Lx, sim.model.grid.Ly, -sim.model.grid.Lz
-    Δz = zspacings(model.grid, Center())
+    Δz = zspacings(sim.model.grid, Center())
     A = Lx * Ly
     z = znodes(sim.model.grid, Center())
 
     tracer = getproperty(sim.model.tracers, parameters.C)
     cmd = parameters.compute_mean_region
-    tfr = parameters.tracer_content_placement
+    tfr = parameters.tracer_flux_placement
 
     lower_region = findall(z .≤ (1 - cmd) * Lz)
     upper_region = findall(z .≥ cmd * Lz)

--- a/test/model_ic_setup.jl
+++ b/test/model_ic_setup.jl
@@ -1,14 +1,14 @@
 ## Random initial conditions
-random_no_steps = 3:10
-number_of_steps = rand(random_no_steps)
-depth_of_steps = reverse(Array(range(domain_extent.Lz+0.2, -0.1, length = number_of_steps)))
-salinity = Array(range(34.57, 34.7, length = number_of_steps+1))
-temperature = Array(range(-1.5, -1.0, length = number_of_steps+1))
+random_no_interfaces = 3:10
+number_of_interfaces = rand(random_no_interfaces)
+depth_of_interfaces = reverse(Array(range(domain_extent.Lz+0.2, -0.1, length = number_of_interfaces)))
+salinity = Array(range(34.57, 34.7, length = number_of_interfaces+1))
+temperature = Array(range(-1.5, -1.0, length = number_of_interfaces+1))
 
 ## Setup the model
 model = DNSModel(architecture, domain_extent, resolution, diffusivities)
 
-step_ics = StepInitialConditions(model, number_of_steps, depth_of_steps, salinity, temperature)
+step_ics = StepInitialConditions(model, number_of_interfaces, depth_of_interfaces, salinity, temperature)
 
 sdns = StaircaseDNS(model, step_ics)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -47,4 +47,10 @@ using Test
 
     end
 
+    @testset "Tracer content restoring" begin
+        include("single_interface_restoring.jl")
+        @test round(initial_upper_T_content, sigdigits = 1) ≈ round(post_upper_T_content, sigdigits = 1)
+        @test round(initial_upper_S_content, sigdigits = 1) ≈ round(post_upper_S_content, sigdigits = 1)
+    end
+
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -50,7 +50,9 @@ using Test
     @testset "Tracer content restoring" begin
         include("single_interface_restoring.jl")
         @test round(initial_upper_T_content, sigdigits = 1) ≈ round(post_upper_T_content, sigdigits = 1)
+        @test round(initial_lower_T_content, sigdigits = 1) ≈ round(post_lower_T_content, sigdigits = 1)
         @test round(initial_upper_S_content, sigdigits = 1) ≈ round(post_upper_S_content, sigdigits = 1)
+        @test round(initial_lower_S_content, sigdigits = 1) ≈ round(post_lower_S_content, sigdigits = 1)
     end
 
 end

--- a/test/single_interface_restoring.jl
+++ b/test/single_interface_restoring.jl
@@ -1,39 +1,29 @@
-using StaircaseShenanigans
-
 architecture = CPU() # or GPU()
 diffusivities = (ν = 1e-5, κ = (S = 1e-8, T = 1e-6))
 domain_extent = (Lx = 0.1, Ly = 0.1, Lz = -1.0)
 resolution = (Nx = 5, Ny = 5, Nz = 70)
 
-## Initial conditions
 number_of_interfaces = 1
 depth_of_interfaces = [-0.5]
 salinity = [34.58, 34.70]
 temperature = [-1.5, 0.5]
 
-## Setup the model
-eos = CustomLinearEquationOfState(-0.5, 34.6)
+model = DNSModel(architecture, domain_extent, resolution, diffusivities)
 
-## restoring
-rate = 1/10
-mask = OuterMask(-0.25, -0.75)
-S_target = OuterTargets(34.58, 34.7, mask)
-T_target = OuterTargets(-1.5, 0.5, mask)
-T_restoring = Relaxation(; rate, mask, target = T_target)
-S_restoring = Relaxation(; rate, mask, target = S_target)
-forcing = (S = S_restoring, T = T_restoring)
-
-## model
-model = DNSModel(architecture, domain_extent, resolution, diffusivities, eos)
-
-## Set initial conditions
-step_ics = StepInitialConditions(model, number_of_interfaces, depth_of_interfaces, salinity, temperature)
+step_ics = StepInitialConditions(model, number_of_steps, depth_of_steps, salinity, temperature)
 
 sdns = StaircaseDNS(model, step_ics)
 
 set_staircase_initial_conditions!(sdns)
 
-## Build simulation
+Δx, Δy, Δz = xspacings(model.grid, Center()), yspacings(model.grid, Center()),
+                zspacings(model.grid, Center())
+
+ΔV = Δx * Δy * Δz
+
+initial_upper_T_content = sum(interior(sdns.model.tracers.T, :, :, upper)) * ΔV
+initial_lower_T_content = sum(interior(sdns.model.tracers.T, :, :, lower)) * ΔV
+
 Δt = 1e-1
 stop_time = 50 * 60 # seconds
 save_schedule = 10  # seconds
@@ -43,5 +33,7 @@ simulation = SDNS_simulation_setup(sdns, Δt, stop_time, save_schedule, save_com
                                     S_and_T_tracer_restoring_callbacks!; output_path, max_Δt = 5,
                                     )
 
-## Run
 run!(simulation)
+
+post_upper_T_content = sum(interior(simulation.model.tracers.T, :, :, upper)) * ΔV
+post_lower_T_content = sum(interior(simulation.model.tracers.T, :, :, lower)) * ΔV

--- a/test/single_interface_restoring.jl
+++ b/test/single_interface_restoring.jl
@@ -10,7 +10,7 @@ temperature = [-1.5, 0.5]
 
 model = DNSModel(architecture, domain_extent, resolution, diffusivities)
 
-step_ics = StepInitialConditions(model, number_of_steps, depth_of_steps, salinity, temperature)
+step_ics = StepInitialConditions(model, number_of_interfaces, depth_of_interfaces, salinity, temperature)
 
 sdns = StaircaseDNS(model, step_ics)
 
@@ -21,8 +21,14 @@ set_staircase_initial_conditions!(sdns)
 
 ΔV = Δx * Δy * Δz
 
+z = znodes(model.grid, Center())
+upper = findall(z .> step_ics.depth_of_interfaces[1] + 0.1)
+lower = findall(z .< step_ics.depth_of_interfaces[1] - 0.1)
+
 initial_upper_T_content = sum(interior(sdns.model.tracers.T, :, :, upper)) * ΔV
 initial_lower_T_content = sum(interior(sdns.model.tracers.T, :, :, lower)) * ΔV
+initial_upper_S_content = sum(interior(sdns.model.tracers.S, :, :, upper)) * ΔV
+initial_lower_S_content = sum(interior(sdns.model.tracers.S, :, :, lower)) * ΔV
 
 Δt = 1e-1
 stop_time = 50 * 60 # seconds
@@ -37,3 +43,5 @@ run!(simulation)
 
 post_upper_T_content = sum(interior(simulation.model.tracers.T, :, :, upper)) * ΔV
 post_lower_T_content = sum(interior(simulation.model.tracers.T, :, :, lower)) * ΔV
+post_upper_S_content = sum(interior(simulation.model.tracers.S, :, :, upper)) * ΔV
+post_lower_S_content = sum(interior(simulation.model.tracers.S, :, :, lower)) * ΔV


### PR DESCRIPTION
This is still a work in progress but I would like to test it on HPC so I will merge and make the necessary fixes (which I will detail in another issue).

The main addition, and what will be refined, is the `Callback` `restore_tracer_content!`. The current implementation is to find the tracer content within some portion of each layer (currently it is to $\pm$ 0.1 from the interface for the upper and lower layer) and whatever tracer content is lost to mixing replace in the top/bottom of the domain to mimic a flux and prevent rundown. It is currently also only designed for a single interface but if it works and is needed it could be extended to a staircase.

A more simple method of just restoring the upper portion of the domain to fixed values has also been added and will be good to have to compare results against.