### PR TITLE
Set initial conditions in constructors

### DIFF
--- a/examples/single_interface.jl
+++ b/examples/single_interface.jl
@@ -16,7 +16,6 @@ velocity_noise = VelocityNoise(0.0, 0.0, 1e-7)
 
 ## setup model
 sdns = StaircaseDNS(model_setup, interface_ics, velocity_noise)
-set_staircase_initial_conditions!(sdns)
 
 ## Build simulation
 Δt = 1e-1
@@ -24,7 +23,7 @@ stop_time = 110 * 60 # seconds
 save_schedule = 10  # seconds
 output_path = joinpath(@__DIR__, "output")
 simulation = SDNS_simulation_setup(sdns, Δt, stop_time, save_schedule, save_computed_output!,
-                                    StaircaseShenanigans.save_vertical_velocities!; output_path, max_Δt = 5,
-                                    )
+                                    StaircaseShenanigans.save_vertical_velocities!;
+                                    output_path, max_Δt = 5)
 ## Run
 run!(simulation)

--- a/examples/single_interface_periodic.jl
+++ b/examples/single_interface_periodic.jl
@@ -11,12 +11,10 @@ model_setup = (;architecture, diffusivities, domain_extent, resolution, eos)
 depth_of_interface = -0.5
 salinity = [34.58, 34.70]
 temperature = [-1.5, 0.5]
-
 interface_ics = PeriodoicSingleInterfaceICs(eos, depth_of_interface, salinity, temperature, tanh_background)
 
 ## setup model
 sdns = StaircaseDNS(model_setup, interface_ics)
-set_staircase_initial_conditions!(sdns)
 
 ## Build simulation
 Δt = 1e-1
@@ -24,7 +22,7 @@ stop_time = 100 * 60 # seconds
 save_schedule = 10  # seconds
 output_path = joinpath(@__DIR__, "output")
 simulation = SDNS_simulation_setup(sdns, Δt, stop_time, save_schedule, save_computed_output!,
-                                    StaircaseShenanigans.save_vertical_velocities!; output_path, max_Δt = 5,
-                                    )
+                                    StaircaseShenanigans.save_vertical_velocities!;
+                                    output_path, max_Δt = 5)
 ## Run
 run!(simulation)

--- a/src/staircase_initial_conditions.jl
+++ b/src/staircase_initial_conditions.jl
@@ -38,7 +38,7 @@ function STSingleInterfaceInitialConditions(eos::BoussinesqEquationOfState, dept
 
     R_ρ = compute_R_ρ(salinity, temperature, depth_of_interface, eos)
 
-return STSingleInterfaceInitialConditions(depth_of_interface, salinity, temperature, R_ρ, maintain_interface)
+    return STSingleInterfaceInitialConditions(depth_of_interface, salinity, temperature, R_ρ, maintain_interface)
 
 end
 const SingleInterfaceICs = STSingleInterfaceInitialConditions # alias


### PR DESCRIPTION
Also `CenteredSecondOrder()` ->  `Centered(order = 2)` for an upcoming release of Oceananigans.jl (this one is backwards compatible).

Also some minor cleanups in the examples (specifically just reducing lines used when calling simulation setup).

Closes #48 

