### PR TITLE
Add `TracerNoise` + setting methods

### DIFF
--- a/examples/single_interface_periodic.jl
+++ b/examples/single_interface_periodic.jl
@@ -12,9 +12,10 @@ depth_of_interface = -0.5
 salinity = [34.58, 34.70]
 temperature = [-1.5, 0.5]
 interface_ics = PeriodoicSingleInterfaceICs(eos, depth_of_interface, salinity, temperature, tanh_background)
+tracer_noise = TracerNoise(1e-6, 1e-6)
 
 ## setup model
-sdns = StaircaseDNS(model_setup, interface_ics)
+sdns = StaircaseDNS(model_setup, interface_ics, tracer_noise)
 
 ## Build simulation
 Δt = 1e-1

--- a/src/StaircaseShenanigans.jl
+++ b/src/StaircaseShenanigans.jl
@@ -30,7 +30,7 @@ export STStaircaseInitialConditions, StaircaseICs, SmoothSTStaircaseInitialCondi
 
 export tanh_background
 
-export AbstractNoise, VelocityNoise
+export AbstractNoise, VelocityNoise, TracerNoise
 
 export OuterStairMask, OuterStairTargets, OuterMask, OuterTargets, ExponentialTarget
 

--- a/src/set_staircase_initial_conditions.jl
+++ b/src/set_staircase_initial_conditions.jl
@@ -42,16 +42,9 @@ function set_staircase_initial_conditions!(model, ics::SingleInterfaceICs)
 
     return nothing
 end
-function set_staircase_initial_conditions!(model, ics::PeriodoicSingleInterfaceICs)
-
-    grid_size = size(model.grid)
-    S₀ = randn(grid_size) * 2e-4
-    T₀ = randn(grid_size) * 2e-4
-
-    set!(model, S = S₀, T = T₀)
-
-    return nothing
-end
+"Here the `BackgroundField` behaves as the `initial_condition` and noise is added to the
+tracer fields to create an instability."
+set_staircase_initial_conditions!(model, ics::PeriodoicSingleInterfaceICs) = nothing
 function set_staircase_initial_conditions!(model, ics::SmoothSTStaircaseInitialConditions)
 
     # TODO: write methods to set smooth changes using the function provied in
@@ -64,17 +57,29 @@ end
 set_noise!(model, noise::Nothing) = nothing
 """
     function set_noise!(model, noise::VelocityNoise)
-Add initial noise the velocity field.
+Add initial noise the `velocity` fields.
 """
 function set_noise!(model, noise::VelocityNoise)
 
     u, v, w = model.velocities
-    u_m, v_m, w_m = noise.u_magnitude, noise.v_magnitude, noise.w_magnitude
-    u_noise = u_m * randn(size(u))
-    v_noise = v_m * randn(size(v))
-    w_noise = w_m * randn(size(w))
+    u_noise = noise.u_magnitude * randn(size(u))
+    v_noise = noise.v_magnitude * randn(size(v))
+    w_noise = noise.w_magnitude * randn(size(w))
 
     set!(model, u = u_noise, v = v_noise, w = w_noise)
+
+end
+"""
+    function set_noise!(model, noise::TracerNoise)
+Add initial noise the `tracer` fields.
+"""
+function set_noise!(model, noise::TracerNoise)
+
+    S, T = model.tracers
+    S_noise = noise.S_magnitude * randn(size(S))
+    T_noise = noise.T_magnitude * randn(size(T))
+
+    set!(model, S = S_noise, T = T_noise)
 
 end
 """

--- a/src/staircase_noise.jl
+++ b/src/staircase_noise.jl
@@ -1,14 +1,24 @@
 """
     struct VelocityNoise{T}
-Container for magnitudes for normally distributed noise added to velocity fields.
+Container for the magnitudes of normally distributed noise added to velocity fields.
 """
 struct VelocityNoise{T} <: AbstractNoise
-    "Magnitude for u velocity field"
+    "Noise magnitude for `u` velocity field"
     u_magnitude :: T
-    "Magnitude for v velocity field"
+    "Noise magnitude for `v` velocity field"
     v_magnitude :: T
-    "Magnitude for w velocity field"
+    "Noise magnitude for `w` velocity field"
     w_magnitude :: T
+end
+"""
+    struct TracerNoise{T}
+Container for the magnitudes of normally distributed noise added to tracer fields.
+"""
+struct TracerNoise{T} <: AbstractNoise
+    "Noise magnitude for `S` tracer field"
+    S_magnitude :: T
+    "Noise magnitude for `T` tracer field"
+    T_magnitude :: T
 end
 Base.iterate(noise::AbstractNoise, state = 1) =
     state > length(fieldnames(noise)) ? nothing : (getfield(noise, state), state + 1)
@@ -19,6 +29,10 @@ function Base.show(io::IO, noise::AbstractNoise)
         println(io, "┣━━ u_noise_magnitude: $(noise.u_magnitude)")
         println(io, "┣━━ v_noise_magnitude: $(noise.v_magnitude)")
         print(io,   "┗━━ w_noise_magnitude: $(noise.w_magnitude)")
+    elseif noise isa TracerNoise
+        println(io, "TracerNoise")
+        println(io, "┣━━ S_noise_magnitude: $(noise.S_magnitude)")
+        print(io,   "┗━━ T_noise_magnitude: $(noise.T_magnitude)")
     end
 end
 "Convenience for all noise at same magnitude `c`, default behaviour is 1e-4"


### PR DESCRIPTION
Allows for more flexibility when setting up a model with triply periodic boundary conditions.

Closes #49 