### PR TITLE
Add density ratio calculation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StaircaseShenanigans"
 uuid = "c2bb06a8-94f3-4279-b990-30bf3ab8ba6f"
 authors = ["Josef Bisits <jbisits@gmail.com>"]
-version = "0.4.0"
+version = "0.4.1"
 
 [deps]
 GibbsSeaWater = "9a22fb26-0b63-4589-b28e-8f9d0b5c3d05"

--- a/examples/single_interface.jl
+++ b/examples/single_interface.jl
@@ -19,11 +19,15 @@ sdns = StaircaseDNS(model_setup, interface_ics, velocity_noise)
 
 ## Build simulation
 Δt = 1e-1
-stop_time = 110 * 60 # seconds
+stop_time = 210 * 60 # seconds
 save_schedule = 10  # seconds
 output_path = joinpath(@__DIR__, "output")
 simulation = SDNS_simulation_setup(sdns, Δt, stop_time, save_schedule, save_computed_output!,
-                                    StaircaseShenanigans.save_vertical_velocities!;
+                                    save_vertical_velocities!;
                                     output_path, max_Δt = 5)
 ## Run
 run!(simulation)
+
+## Compute density ratio
+compute_R_ρ!(simulation.output_writers[:computed_output].filepath,
+             simulation.output_writers[:tracers].filepath, eos)

--- a/examples/single_interface_periodic.jl
+++ b/examples/single_interface_periodic.jl
@@ -19,7 +19,7 @@ sdns = StaircaseDNS(model_setup, interface_ics, tracer_noise)
 
 ## Build simulation
 Δt = 1e-1
-stop_time = 100 * 60 # seconds
+stop_time = 200 * 60 # seconds
 save_schedule = 10  # seconds
 output_path = joinpath(@__DIR__, "output")
 simulation = SDNS_simulation_setup(sdns, Δt, stop_time, save_schedule, save_computed_output!,
@@ -27,3 +27,7 @@ simulation = SDNS_simulation_setup(sdns, Δt, stop_time, save_schedule, save_com
                                     output_path, max_Δt = 5)
 ## Run
 run!(simulation)
+
+## Compute density ratio
+compute_R_ρ!(simulation.output_writers[:computed_output].filepath,
+             simulation.output_writers[:tracers].filepath, eos)

--- a/src/StaircaseShenanigans.jl
+++ b/src/StaircaseShenanigans.jl
@@ -4,6 +4,7 @@ using Oceananigans, Reexport, Printf
 using Oceananigans: seawater_density
 using Oceananigans.BoundaryConditions: update_boundary_condition!
 using Oceananigans.Operators: ℑzᵃᵃᶠ
+using Oceananigans.Fields: condition_operand
 using SeawaterPolynomials.TEOS10
 using SeawaterPolynomials.SecondOrderSeawaterPolynomials
 using SeawaterPolynomials: BoussinesqEquationOfState
@@ -36,12 +37,15 @@ export OuterStairMask, OuterStairTargets, OuterMask, OuterTargets, ExponentialTa
 
 export CustomLinearRoquetSeawaterPolynomial, CustomLinearEquationOfState
 
-export save_computed_output!
+export save_computed_output!, save_all_velocities!, save_vertical_velocities!
+
+export compute_R_ρ!
 
 export animate_tracers, animate_density, visualise_initial_conditions, visualise_initial_density
 
 include("staircase_initial_conditions.jl")
 include("staircase_noise.jl")
+include("staircase_diagnostics.jl")
 include("staircase_model.jl")
 include("set_staircase_initial_conditions.jl")
 include("staircase_restoring.jl")

--- a/src/staircase_diagnostics.jl
+++ b/src/staircase_diagnostics.jl
@@ -1,0 +1,39 @@
+"Condition for lower quarter of domain."
+lower_quarter(i, j, k, grid, c) = k < grid.Nz / 4
+"Condition for lower quarter of domain."
+upper_quarter(i, j, k, grid, c) = 3 * grid.Nz / 4 < k < grid.Nz
+
+"""
+    function compute_R_ρ!(computed_output::AbstractString, tracers::AbstractString, eos)
+From saved `tracers` output get the averaged salinity and temperature and lower and upper
+quarter of the domain, compute the density ratio and save to `computed_output`.
+**Note:** this method *needs the equation of state* used in the model so best practice is to
+compute this at the end of a script so everything can be easily accessed (see a singlge
+interface example).
+"""
+function compute_R_ρ!(computed_output::AbstractString, tracers::AbstractString, eos)
+
+    ds = NCDataset(tracers)
+
+    S_u = S_g = ds[:Sᵤ_mean][:]
+    S_l = S_f = ds[:Sₗ_mean][:]
+    T_u = T_f = ds[:Tᵤ_mean][:]
+    T_l = T_g = ds[:Tₗ_mean][:]
+
+    eos_vec = fill(eos, length(S_u))
+    ρ_u = ρ.(T_u, S_u, 0, eos_vec)
+    ρ_l = ρ.(T_l, S_l, 0, eos_vec)
+    ρ_f = ρ.(T_f, S_f, 0, eos_vec)
+    ρ_g = ρ.(T_g, S_g, 0, eos_vec)
+
+    R_ρ = @. (0.5 * (ρ_f - ρ_u) + 0.5 * (ρ_l - ρ_g)) / (0.5 * (ρ_f - ρ_l) + 0.5 * (ρ_u - ρ_g))
+
+    NCDataset(computed_output, "a") do ds2
+        defVar(ds2, "R_ρ", R_ρ, ("time",),
+                attrib = Dict("long_name" => "Density ratio"))
+    end
+
+    close(ds)
+
+    return nothing
+end

--- a/src/staircase_initial_conditions.jl
+++ b/src/staircase_initial_conditions.jl
@@ -104,15 +104,15 @@ function compute_R_ρ(salinity, temperature, depth_of_interfaces::Array, eos)
 
     S_u = S_g = @view salinity[1:end-1]
     S_l = S_f = @view salinity[2:end]
-    Θ_u = Θ_f = @view temperature[1:end-1]
-    Θ_l = Θ_g = @view temperature[2:end]
+    T_u = T_f = @view temperature[1:end-1]
+    T_l = T_g = @view temperature[2:end]
 
     eos_vec = fill(eos, length(S_u))
 
-    ρ_u = ρ.(Θ_u, S_u, depth_of_interfaces, eos_vec)
-    ρ_l = ρ.(Θ_l, S_l, depth_of_interfaces, eos_vec)
-    ρ_f = ρ.(Θ_f, S_f, depth_of_interfaces, eos_vec)
-    ρ_g = ρ.(Θ_g, S_g, depth_of_interfaces, eos_vec)
+    ρ_u = ρ.(T_u, S_u, depth_of_interfaces, eos_vec)
+    ρ_l = ρ.(T_l, S_l, depth_of_interfaces, eos_vec)
+    ρ_f = ρ.(T_f, S_f, depth_of_interfaces, eos_vec)
+    ρ_g = ρ.(T_g, S_g, depth_of_interfaces, eos_vec)
 
     R_ρ = @. (0.5 * (ρ_f - ρ_u) + 0.5 * (ρ_l - ρ_g)) / (0.5 * (ρ_f - ρ_l) + 0.5 * (ρ_u - ρ_g))
 
@@ -122,13 +122,13 @@ function compute_R_ρ(salinity, temperature, depth_of_interfaces::Number, eos)
 
     S_u = S_g = salinity[1]
     S_l = S_f = salinity[2]
-    Θ_u = Θ_f = temperature[1]
-    Θ_l = Θ_g = temperature[2]
+    T_u = T_f = temperature[1]
+    T_l = T_g = temperature[2]
 
-    ρ_u = ρ(Θ_u, S_u, depth_of_interfaces, eos)
-    ρ_l = ρ(Θ_l, S_l, depth_of_interfaces, eos)
-    ρ_f = ρ(Θ_f, S_f, depth_of_interfaces, eos)
-    ρ_g = ρ(Θ_g, S_g, depth_of_interfaces, eos)
+    ρ_u = ρ(T_u, S_u, depth_of_interfaces, eos)
+    ρ_l = ρ(T_l, S_l, depth_of_interfaces, eos)
+    ρ_f = ρ(T_f, S_f, depth_of_interfaces, eos)
+    ρ_g = ρ(T_g, S_g, depth_of_interfaces, eos)
 
     return (0.5 * (ρ_f - ρ_u) + 0.5 * (ρ_l - ρ_g)) / (0.5 * (ρ_f - ρ_l) + 0.5 * (ρ_u - ρ_g))
 end


### PR DESCRIPTION
This does not do it on the fly. Instead the mean salinity and temperature are saved in the upper and lower regions of the domain and are used to compute the density ratio and append to output. It is very fast and potentially better than doing on the fly with some of the issues I ran in to.

Closes #2 