### PR TITLE
Return `NameTuple` of diffs ready for use

### DIFF
--- a/src/StaircaseShenanigans.jl
+++ b/src/StaircaseShenanigans.jl
@@ -27,7 +27,7 @@ abstract type AbstractBackgroundFunction end
 abstract type AbstractInterfaceSmoothing end
 
 export StaircaseDNS, DNSModel, SDNS_simulation_setup, enhance_κₛ, enhance_κₜ,
-       κₛ_and_κₜ_from_ν, ν_and_κₛ_from_κₜ
+       diffusivities_from_ν, diffusivities_from_κₜ
 
 export STStaircaseInitialConditions, StaircaseICs, SmoothSTStaircaseInitialConditions,
        STSingleInterfaceInitialConditions, SingleInterfaceICs,

--- a/src/staircase_model.jl
+++ b/src/staircase_model.jl
@@ -160,24 +160,24 @@ time `p.diff_change`. Note `p.diff_change` is expeceted in minutes.
 """
     function κ_from_ν(ν; τ = 0.01, Pr = 7)
 Get the salinity and temperature diffusivities from a set kinematic viscosity and diffusivity
-ratio and Prandtl number.
+ratio and Prandtl number. Returns a `NamedTuple` which can be passed to build a model.
 """
 function κₛ_and_κₜ_from_ν(ν; τ = 0.01, Pr = 7)
 
     κₜ = round(ν / Pr, digits = 8)
     κₛ = round(τ * κₜ, digits = 10)
 
-    return κₜ, κₛ
+    return (; ν, κ=(T=κₜ, S=κₛ))
 end
 """
     function ν_and_κₛ_from_κₜ(κₜ; τ = 0.01, Pr = 7)
 Get kinematic viscosity and salinity diffusivity from a set temperature diffusivity and
-diffusivity and Prandtl number.
+diffusivity and Prandtl number. Returns a `NamedTuple` which can be passed to build a model.
 """
 function ν_and_κₛ_from_κₜ(κₜ; τ = 0.01, Pr = 7)
 
     ν = round(Pr * κₜ, digits = 7)
     κₛ = round(τ * κₜ, digits = 10)
 
-    return ν, κₛ
+    return (; ν, κ=(T=κₜ, S=κₛ))
 end

--- a/src/staircase_model.jl
+++ b/src/staircase_model.jl
@@ -158,11 +158,11 @@ time `p.diff_change`. Note `p.diff_change` is expeceted in minutes.
 """
 @inline enhance_κₜ(i, j, k, grid, clock, fields, p) = clock.time < p.diff_change * 60 ? p.κₜ : p.κₜ * p.enhance
 """
-    function κ_from_ν(ν; τ = 0.01, Pr = 7)
-Get the salinity and temperature diffusivities from a set kinematic viscosity and diffusivity
+    function diffusivities_from_ν(ν; τ = 0.01, Pr = 7)
+Get the salinity and temperature diffusivities from a set kinematic viscosity, diffusivity
 ratio and Prandtl number. Returns a `NamedTuple` which can be passed to build a model.
 """
-function κₛ_and_κₜ_from_ν(ν; τ = 0.01, Pr = 7)
+function diffusivities_from_ν(ν; τ = 0.01, Pr = 7)
 
     κₜ = round(ν / Pr, digits = 8)
     κₛ = round(τ * κₜ, digits = 10)
@@ -170,11 +170,11 @@ function κₛ_and_κₜ_from_ν(ν; τ = 0.01, Pr = 7)
     return (; ν, κ=(T=κₜ, S=κₛ))
 end
 """
-    function ν_and_κₛ_from_κₜ(κₜ; τ = 0.01, Pr = 7)
-Get kinematic viscosity and salinity diffusivity from a set temperature diffusivity and
-diffusivity and Prandtl number. Returns a `NamedTuple` which can be passed to build a model.
+    function diffusivities_from_κₜ(κₜ; τ = 0.01, Pr = 7)
+Get kinematic viscosity and salinity diffusivity from a set temperature diffusivity,
+diffusivity ratio and Prandtl number. Returns a `NamedTuple` which can be passed to build a model.
 """
-function ν_and_κₛ_from_κₜ(κₜ; τ = 0.01, Pr = 7)
+function diffusivities_from_κₜ(κₜ; τ = 0.01, Pr = 7)
 
     ν = round(Pr * κₜ, digits = 7)
     κₛ = round(τ * κₜ, digits = 10)

--- a/src/staircase_simulation.jl
+++ b/src/staircase_simulation.jl
@@ -94,7 +94,7 @@ function non_dimensional_numbers!(simulation::Simulation, sdns::StaircaseDNS)
     model, initial_conditions = sdns.model, sdns.initial_conditions
     eos = model.buoyancy.formulation.equation_of_state
     ν = model.closure.ν
-    κₛ, κₜ = model.closure.κ
+    κₛ, κₜ = model.closure.κ.S, model.closure.κ.T
     Pr = ν / κₜ
     Sc = ν / κₛ
     Le = κₜ / κₛ

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -155,19 +155,22 @@ using Test
     @testset "Diffusivity from non-dim numbers" begin
 
         ν = 1e-6
-        κₜ, κₛ = κₛ_and_κₜ_from_ν(ν, Pr = 10)
-        @test κₜ == 1e-7
-        @test κₛ == 1e-9
-        κₜ, κₛ = κₛ_and_κₜ_from_ν(ν, τ = 0.1, Pr = 10)
-        @test κₜ == 1e-7
-        @test κₛ == 1e-8
+        diffs = κₛ_and_κₜ_from_ν(ν, Pr = 10)
+        @test diffs.ν == ν
+        @test diffs.κ.T == 1e-7
+        @test diffs.κ.S == 1e-9
+        diffs = κₛ_and_κₜ_from_ν(ν, τ = 0.1, Pr = 10)
+        @test diffs.κ.T == 1e-7
+        @test diffs.κ.S == 1e-8
+        @test diffs.ν == ν
         κₜ = 1e-7
-        ν, κₛ = ν_and_κₛ_from_κₜ(κₜ, Pr = 10)
-        @test ν == 1e-6
-        @test κₛ == 1e-9
-        ν, κₛ = ν_and_κₛ_from_κₜ(κₜ, τ = 0.1, Pr = 10)
-        @test ν == 1e-6
-        @test κₛ == 1e-8
-
+        diffs = ν_and_κₛ_from_κₜ(κₜ, Pr = 10)
+        @test diffs.ν == 1e-6
+        @test diffs.κ.S == 1e-9
+        @test diffs.κ.T == κₜ
+        diffs = ν_and_κₛ_from_κₜ(κₜ, τ = 0.1, Pr = 10)
+        @test diffs.ν == 1e-6
+        @test diffs.κ.S == 1e-8
+        @test diffs.κ.T == κₜ
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -155,20 +155,20 @@ using Test
     @testset "Diffusivity from non-dim numbers" begin
 
         ν = 1e-6
-        diffs = κₛ_and_κₜ_from_ν(ν, Pr = 10)
+        diffs = diffusivities_from_ν(ν, Pr = 10)
         @test diffs.ν == ν
         @test diffs.κ.T == 1e-7
         @test diffs.κ.S == 1e-9
-        diffs = κₛ_and_κₜ_from_ν(ν, τ = 0.1, Pr = 10)
+        diffs = diffusivities_from_ν(ν, τ = 0.1, Pr = 10)
         @test diffs.κ.T == 1e-7
         @test diffs.κ.S == 1e-8
         @test diffs.ν == ν
         κₜ = 1e-7
-        diffs = ν_and_κₛ_from_κₜ(κₜ, Pr = 10)
+        diffs = diffusivities_from_κₜ(κₜ, Pr = 10)
         @test diffs.ν == 1e-6
         @test diffs.κ.S == 1e-9
         @test diffs.κ.T == κₜ
-        diffs = ν_and_κₛ_from_κₜ(κₜ, τ = 0.1, Pr = 10)
+        diffs = diffusivities_from_κₜ(κₜ, τ = 0.1, Pr = 10)
         @test diffs.ν == 1e-6
         @test diffs.κ.S == 1e-8
         @test diffs.κ.T == κₜ


### PR DESCRIPTION
Rather than manually passing them which could lead to error.