### PR TITLE
Enhance with turbulent diffusivity

### DIFF
--- a/src/staircase_model.jl
+++ b/src/staircase_model.jl
@@ -150,13 +150,13 @@ Enhance the isotropic, scalar diffusiviy applied to the salintiy field by `p.enh
 to give same enhancement to enhanced diffusivity as temperature, after time = `p.diff_change`.
 Note `p.diff_change` is expeceted in minutes.
 """
-@inline enhance_κₛ(i, j, k, grid, clock, fields, p) = p.start_enhance * 60 < clock.time < p.end_enhance * 60 ? p.κₛ * p.enhance / p.τ : p.κₛ
+@inline enhance_κₛ(i, j, k, grid, clock, fields, p) = p.start_enhance * 60 < clock.time < p.end_enhance * 60 ? p.κₛ + p.κ_turb : p.κₛ
 """
     enhance_enhance_κₜ(i, j, k, grid, clock, fields, p)
 Enhance the isotropic, scalar diffusiviy applied to the temperature field by `p.enhance` after
 time `p.diff_change`. Note `p.diff_change` is expeceted in minutes.
 """
-@inline enhance_κₜ(i, j, k, grid, clock, fields, p) = p.start_enhance * 60 < clock.time < p.end_enhance * 60 ? p.κₜ * p.enhance : p.κₜ
+@inline enhance_κₜ(i, j, k, grid, clock, fields, p) = p.start_enhance * 60 < clock.time < p.end_enhance * 60 ? p.κₜ + p.κ_turb : p.κₜ
 """
     function diffusivities_from_ν(ν; τ = 0.01, Pr = 7)
 Get the salinity and temperature diffusivities from a set kinematic viscosity, diffusivity

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -158,7 +158,7 @@ using Test, CairoMakie
 
         diffusivities = (ν = 1e-5, κ = (S = enhance_κₛ, T = enhance_κₜ),
                         parameters = (κₛ = 1e-8, κₜ = 1e-6, start_enhance = 1/60, end_enhance = 2/60,
-                                      enhance = 10, τ = 1e-8 / 1e-6),
+                                      κ_turb = 1e-3),
                         discrete_form = true)
         model = DNSModel(architecture, diffusivities, domain_extent, domain_topology, resolution)
         stop_time = 5


### PR DESCRIPTION
This changes the way turbulence is enhanced. Instead of making them equal and enhancing, a turbulent diffusivity is added to both salinity and temperature molecular diffusivities. So they are not exactly the same but the magnitude of the enhanced turbulent diffusivity should make the difference  negligible.