### PR TITLE
Remove saving of interface thickness

### DIFF
--- a/src/staircase_diagnostics.jl
+++ b/src/staircase_diagnostics.jl
@@ -115,7 +115,6 @@ function save_diagnostics!(diagnostics_file::AbstractString, tracers::AbstractSt
             initial_non_dim_numbers!(diagnostics_file, computed_output, group)
             save_horizontally_averaged_fields!(diagnostics_file, computed_output, tracers, group)
             compute_Ẽ!(diagnostics_file, computed_output, tracers, group, interface_offset)
-            interface_thickness!(diagnostics_file, tracers, group)
 
         end
 
@@ -134,7 +133,6 @@ function save_diagnostics!(diagnostics_file::AbstractString, tracers::AbstractSt
         initial_non_dim_numbers!(diagnostics_file, computed_output, group)
         save_horizontally_averaged_fields!(diagnostics_file, computed_output, tracers, group)
         compute_Ẽ!(diagnostics_file, computed_output, tracers, group, interface_offset)
-        interface_thickness!(diagnostics_file, tracers, group)
 
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -146,11 +146,6 @@ using Test, CairoMakie
                           simulation.output_writers[:computed_output].filepath)
         @test isfile(diagnostics_file)
 
-        update_diagnostic!(diagnostics_file, "lineareos", "hₜ",
-                            simulation.output_writers[:tracers].filepath,
-                            simulation.output_writers[:computed_output].filepath)
-        @test isfile(diagnostics_file)
-
         update_diagnostic!(diagnostics_file, "nonlineareos", "Ẽ",
                             simulation.output_writers[:tracers].filepath,
                             simulation.output_writers[:computed_output].filepath,


### PR DESCRIPTION
This is erroring when looking at the flux boundary condition case and is not something I am using so removing.