### PR TITLE
Move to isotropic KE dissipation rate

### DIFF
--- a/src/StaircaseShenanigans.jl
+++ b/src/StaircaseShenanigans.jl
@@ -14,7 +14,7 @@ using SeawaterPolynomials: thermal_expansion, haline_contraction, total_density
 using GibbsSeaWater: gsw_alpha, gsw_beta
 using NCDatasets, JLD2
 using Statistics
-using Oceanostics: KineticEnergyDissipationRate, KineticEnergy, PotentialEnergy, BuoyancyProductionTerm
+using Oceanostics: IsotropicKineticEnergyDissipationRate, KineticEnergy, PotentialEnergy, BuoyancyProductionTerm
 
 import SeawaterPolynomials.SecondOrderSeawaterPolynomials: RoquetSeawaterPolynomial
 

--- a/src/staircase_simulation.jl
+++ b/src/staircase_simulation.jl
@@ -318,7 +318,7 @@ function save_computed_output!(simulation, sdns, schedule, save_file, output_dir
     σ_ha = Average(σ, dims = (1, 2))
     N² = buoyancy_frequency(model)
     N²_ha = Average(N², dims = (1, 2))
-    ε = KineticEnergyDissipationRate(model)
+    ε = IsotropicKineticEnergyDissipationRate(model)
     ∫ε = Integral(ε)
     ε_maximum = Reduction(maximum!, ε, dims = (1, 2, 3))
     Eₖ = KineticEnergy(model)


### PR DESCRIPTION
DNS should have isotropic closures so this seems more appropriate. Might also help with energy budget.